### PR TITLE
検索ワードをハイライトする処理を追加

### DIFF
--- a/resources/views/reviews/search.blade.php
+++ b/resources/views/reviews/search.blade.php
@@ -21,18 +21,19 @@
     </div><!-- /.review-left -->
     <div class="review-right">
       <div class="review-top">
-        <h2>{{$review->live_date}} {{$review->title}}</h2>
+        <h2>{{$review->live_date}} <span class="search-review-text">{{$review->title}}</span></h2>
         <a href="modify?id={{$review->id}}" class="review-action">
           <i class="fas fa-ellipsis-h"></i>
         </a>
       </div><!-- /.review-right-top -->
       <div class="tags">
         @foreach ($review->tags as $tag)
+        <!-- TODO:タグもハイライト出来るようにする -->
         <a href="#" class="tag">{{$tag->tag_name}}</a>
         @endforeach
       </div>
-      <p>{{$review->text}}</p>
-      <div class="review-bottom">      
+      <p class="search-review-text">{!! nl2br(e($review->text)) !!}</p>
+      <div class="review-bottom">
         <span class="user-name">by <a href="user?user_id={{$review->user_id}}">{{$review->user->account_name}}さん</span></a>
         <span class="created-at">{{$review->created_at}}</span>
         <span class="likes">
@@ -43,6 +44,28 @@
     </div><!-- /.review-right -->
   </div><!-- /.main-newReview 1投稿のお尻 -->
   @endforeach
+  <script>
+    // 検索ワードをハイライトする処理
+    // TODO:平仮名とカタカナを区別しないでハイライト出来るようにする
+    const keyword = '{{$keyword}}';
+    const highlightedKeyword = '<span style="background-color:#FFFF00;">' + keyword + '</span>';
+
+    let reviewHTMLs = Array.prototype.slice.call(document.getElementsByClassName('search-review-text'));
+    reviewHTMLs.forEach((reviewHTML, i) => {
+        let reviewText = reviewHTML.innerText;
+        let highlightedReviewText = reviewText.replace(new RegExp(keyword, 'g'), highlightedKeyword);
+        // 置換対象テキスト作成
+        reviewText = reviewText.replace(/\n/g, '<br>');
+        // 置換先テキスト作成
+        highlightedReviewText = highlightedReviewText.replace(/\n/g, '<br>');
+        // 置換できるように不要な改行コードを削除
+        reviewHTML = reviewHTML.innerHTML.replace(/\n/g, '');
+        // reviewHTMLに含まれている全ての置換対象テキストを置換先テキストに置換
+        const highlightedReviewHTML = reviewHTML.replace(new RegExp(reviewText,'g'), highlightedReviewText);
+        document.getElementsByClassName('search-review-text')[i].innerHTML = highlightedReviewHTML;
+    });
+  </script>
+
   {{ $reviews->links('vendor.pagination.bootstrap-4')}}
 @endsection
 @section('js')


### PR DESCRIPTION
平仮名とカタカナを区別しないでハイライト出来るようにしようと思ったのですが、
平仮名とカタカナが混ざっているパターンなどを考えると難しかったので、
一旦、完全一致した場合のみハイライトするようにしています。
時間あれば考えます（やらなそう、、、）